### PR TITLE
Optimize the build job for publish-github-release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,13 +40,15 @@ jobs:
 
   publish-github-release:
     docker:
-      - image: circleci/ruby:2.4.2-jessie-node
+      - image: ruby:2.4.2-slim-jessie
     working_directory: /tmp/workspace/osprey/
     steps:
       - attach_workspace:
           at: /tmp/workspace
       - run: cd bootstrapper/debian && bash -x make-deb $CIRCLE_TAG
       - run: cd autossh/debian && bash -x make-deb $CIRCLE_TAG
+      - run: cd platform/low-level-control-service/debian && bash -x make-deb $CIRCLE_TAG
+      - run: cd platform/metapackage/debian && bash -x make-deb $CIRCLE_TAG
       - run: gem install deb-s3
       - run: cd bootstrapper/debian && deb-s3 upload osprey-bootstrapper-$CIRCLE_TAG.deb --bucket osprey-groundstation --preserve-versions --s3-region=${AWS_REGION}
       - run: cd autossh/debian && deb-s3 upload osprey-autossh-$CIRCLE_TAG.deb --bucket osprey-groundstation --preserve-versions --s3-region=${AWS_REGION}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ workflows:
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.9
+      - image: golang:1.9-alpine
     working_directory: /go/src/github.com/jringstad/osprey/
     steps:
       - checkout:
@@ -40,15 +40,18 @@ jobs:
 
   publish-github-release:
     docker:
-      - image: ruby:2.4.2-slim-jessie
+      - image: ruby:2.4.2-alpine
     working_directory: /tmp/workspace/osprey/
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - run: cd bootstrapper/debian && bash -x make-deb $CIRCLE_TAG
-      - run: cd autossh/debian && bash -x make-deb $CIRCLE_TAG
-      - run: cd platform/low-level-control-service/debian && bash -x make-deb $CIRCLE_TAG
-      - run: cd platform/metapackage/debian && bash -x make-deb $CIRCLE_TAG
+      - run: apk --update add xz
+      - run: apk add --no-cache dpkg
+      - run: apk --update add tar
+      - run: cd bootstrapper/debian && sh -x make-deb $CIRCLE_TAG
+      - run: cd autossh/debian && sh -x make-deb $CIRCLE_TAG
+      - run: cd platform/low-level-control-service/debian && sh -x make-deb $CIRCLE_TAG
+      - run: cd platform/metapackage/debian && sh -x make-deb $CIRCLE_TAG
       - run: gem install deb-s3
       - run: cd bootstrapper/debian && deb-s3 upload osprey-bootstrapper-$CIRCLE_TAG.deb --bucket osprey-groundstation --preserve-versions --s3-region=${AWS_REGION}
       - run: cd autossh/debian && deb-s3 upload osprey-autossh-$CIRCLE_TAG.deb --bucket osprey-groundstation --preserve-versions --s3-region=${AWS_REGION}

--- a/autossh/debian/make-deb
+++ b/autossh/debian/make-deb
@@ -13,4 +13,4 @@ cp misc/control osprey-autossh-$TAG/DEBIAN/
 cp misc/rules osprey-autossh-$TAG/DEBIAN/
 sed -e "s/RELEASE_TAG/$TAG/" -i osprey-autossh-$TAG/DEBIAN/control
 
-dpkg-deb --build osprey-autossh-$TAG
+dpkg --build osprey-autossh-$TAG

--- a/bootstrapper/debian/make-deb
+++ b/bootstrapper/debian/make-deb
@@ -15,4 +15,4 @@ cp misc/control osprey-bootstrapper-$TAG/DEBIAN/
 cp misc/rules osprey-bootstrapper-$TAG/DEBIAN/
 sed -e "s/RELEASE_TAG/$TAG/" -i osprey-bootstrapper-$TAG/DEBIAN/control
 
-dpkg-deb --build osprey-bootstrapper-$TAG
+dpkg --build osprey-bootstrapper-$TAG

--- a/platform-diagnostics/make-deb
+++ b/platform-diagnostics/make-deb
@@ -11,4 +11,4 @@ cp misc/control osprey-diagnostics-$TAG/DEBIAN/
 cp misc/osprey-diagnostics.service osprey-diagnostics-$TAG/DEBIAN/
 cp misc/osprey-diagnostics.timer osprey-diagnostics-$TAG/DEBIAN/
 
-dpkg-deb --build osprey-diagnostics-$TAG
+dpkg --build osprey-diagnostics-$TAG

--- a/platform/low-level-control-service/debian/make-deb
+++ b/platform/low-level-control-service/debian/make-deb
@@ -13,4 +13,4 @@ cp misc/control osprey-$NAME-$TAG/DEBIAN/
 cp misc/rules osprey-$NAME-$TAG/DEBIAN/
 sed -e "s/RELEASE_TAG/$TAG/g" -i osprey-$NAME-$TAG/DEBIAN/control
 
-dpkg-deb --build osprey-$NAME-$TAG
+dpkg --build osprey-$NAME-$TAG

--- a/platform/metapackage/debian/make-deb
+++ b/platform/metapackage/debian/make-deb
@@ -8,4 +8,4 @@ mkdir -p osprey-$NAME-$TAG/DEBIAN/
 cp misc/control osprey-$NAME-$TAG/DEBIAN/
 sed -e "s/RELEASE_TAG/$TAG/g" -i osprey-$NAME-$TAG/DEBIAN/control
 
-dpkg-deb --build osprey-$NAME-$TAG
+dpkg --build osprey-$NAME-$TAG


### PR DESCRIPTION
Replacing circleci/ruby:2.4.2-jessie-node with ruby:2.4.2-slim-jessie reduces the image size by approximately 300MB. However, it seems the build process is not successful unless
low-level-control-service/debian and platform/metapackage/debian are packaged (perhaps repackaged?). This is a working solution, and will try to further optimize with an alpine image. Alpine image might require additional tweaks to the shell scrips make-deb. 